### PR TITLE
verifier tests

### DIFF
--- a/authn/interfaces.go
+++ b/authn/interfaces.go
@@ -7,7 +7,7 @@ import (
 
 // Provides a JSON Web Key from a Key ID
 // Wanted to use function signature from go-jose.v2
-// but that would make use lose error information
+// but that would make us lose error information
 type jwkProvider interface {
 	Key(kid string) ([]jose.JSONWebKey, error)
 }

--- a/authn/internal_client.go
+++ b/authn/internal_client.go
@@ -15,6 +15,10 @@ type internalClient struct {
 }
 
 func newInternalClient(base string) (*internalClient, error) {
+	// ensure that base ends with a '/', so ResolveReference() will work as desired
+	if base[len(base)-1] != '/' {
+		base = base + "/"
+	}
 	baseURL, err := url.Parse(base)
 	if err != nil {
 		return nil, err
@@ -23,6 +27,7 @@ func newInternalClient(base string) (*internalClient, error) {
 	return &internalClient{baseURL: baseURL}, nil
 }
 
+// TODO: test coverage
 func (ic *internalClient) Key(kid string) ([]jose.JSONWebKey, error) {
 	resp, err := http.Get(ic.absoluteURL("jwks"))
 	if err != nil {
@@ -31,7 +36,7 @@ func (ic *internalClient) Key(kid string) ([]jose.JSONWebKey, error) {
 	defer resp.Body.Close()
 
 	if !isStatusSuccess(resp.StatusCode) {
-		return []jose.JSONWebKey{}, fmt.Errorf("Failed to get jwks from jwk url: %s", ic.absoluteURL("jwks"))
+		return []jose.JSONWebKey{}, fmt.Errorf("Received %d from %s", resp.StatusCode, ic.absoluteURL("jwks"))
 	}
 
 	bodyBytes, err := ioutil.ReadAll(resp.Body)

--- a/authn/internal_client_test.go
+++ b/authn/internal_client_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestInternalClient(t *testing.T) {
-	t.Run("absolute URLs", func(t *testing.T) {
+	t.Run("absoluteURL", func(t *testing.T) {
 		testCases := []struct {
 			baseURL     string
 			path        string
@@ -16,8 +16,8 @@ func TestInternalClient(t *testing.T) {
 		}{
 			{"https://authn.keratin.tech", "path", "https://authn.keratin.tech/path"},
 			{"https://authn.keratin.tech/", "path", "https://authn.keratin.tech/path"},
-			{"https://authn.keratin.tech/dir", "path", "https://authn.keratin.tech/dir/path"},
-			{"https://authn.keratin.tech/dir/", "path", "https://authn.keratin.tech/dir/path"},
+			{"https://keratin.tech/authn", "path", "https://keratin.tech/authn/path"},
+			{"https://keratin.tech/authn/", "path", "https://keratin.tech/authn/path"},
 		}
 
 		for _, tc := range testCases {

--- a/authn/internal_client_test.go
+++ b/authn/internal_client_test.go
@@ -1,0 +1,31 @@
+package authn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInternalClient(t *testing.T) {
+	t.Run("absolute URLs", func(t *testing.T) {
+		testCases := []struct {
+			baseURL     string
+			path        string
+			absoluteURL string
+		}{
+			{"https://authn.keratin.tech", "path", "https://authn.keratin.tech/path"},
+			{"https://authn.keratin.tech/", "path", "https://authn.keratin.tech/path"},
+			{"https://authn.keratin.tech/dir", "path", "https://authn.keratin.tech/dir/path"},
+			{"https://authn.keratin.tech/dir/", "path", "https://authn.keratin.tech/dir/path"},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.baseURL, func(t *testing.T) {
+				ic, err := newInternalClient(tc.baseURL)
+				require.NoError(t, err)
+				assert.Equal(t, tc.absoluteURL, ic.absoluteURL(tc.path))
+			})
+		}
+	})
+}

--- a/authn/verifier_test.go
+++ b/authn/verifier_test.go
@@ -1,0 +1,229 @@
+package authn
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	jose "gopkg.in/square/go-jose.v2"
+	jwt "gopkg.in/square/go-jose.v2/jwt"
+)
+
+func TestIDTokenVerifier(t *testing.T) {
+	// the good test key
+	defaultKey, err := rsa.GenerateKey(rand.Reader, 512)
+	require.NoError(t, err)
+	defaultJWK := jose.JSONWebKey{Key: defaultKey, KeyID: "defaultKey"}
+
+	// build a verifier
+	jwks := &mockJwkProvider{key_map: map[string]jose.JSONWebKey{}}
+	jwks.key_map[defaultJWK.KeyID] = jose.JSONWebKey{Key: defaultKey.Public(), KeyID: "defaultKey"}
+	config := Config{
+		Issuer:   "https://authn.example.com",
+		Audience: "app.example.com",
+	}
+	verifier, err := newIDTokenVerifier(config, jwks)
+	require.NoError(t, err)
+
+	// factory defaults
+	randInt, err := rand.Int(rand.Reader, big.NewInt(99999))
+	require.NoError(t, err)
+	defaultClaims := jwt.Claims{
+		Issuer:   config.Issuer,
+		Audience: jwt.Audience{config.Audience},
+		Subject:  randInt.String(),
+		Expiry:   jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		IssuedAt: jwt.NewNumericDate(time.Now().Add(-time.Minute)),
+	}
+	defaultSigner, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: defaultJWK},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		token, err := jwt.Signed(defaultSigner).Claims(defaultClaims).CompactSerialize()
+		require.NoError(t, err)
+
+		claims, err := verifier.GetVerifiedClaims(token)
+		require.NoError(t, err)
+
+		assert.Equal(t, defaultClaims.Subject, claims.Subject)
+	})
+
+	t.Run("audience string", func(t *testing.T) {
+		token, err := jwt.Signed(defaultSigner).Claims(map[string]interface{}{
+			"iss": defaultClaims.Issuer,
+			"aud": config.Audience,
+			"sub": defaultClaims.Subject,
+			"exp": defaultClaims.Expiry.Time().Unix(),
+			"iat": defaultClaims.IssuedAt.Time().Unix(),
+		}).CompactSerialize()
+		require.NoError(t, err)
+
+		claims, err := verifier.GetVerifiedClaims(token)
+		require.NoError(t, err)
+
+		assert.Equal(t, defaultClaims.Subject, claims.Subject)
+	})
+
+	t.Run("URL-equivalent issuer", func(t *testing.T) {
+		testClaims := defaultClaims
+		testClaims.Issuer = "https://authn.example.com/"
+		token, err := jwt.Signed(defaultSigner).Claims(testClaims).CompactSerialize()
+		require.NoError(t, err)
+
+		// See: https://github.com/keratin/authn-go/issues/3
+		_, err = verifier.GetVerifiedClaims(token)
+		assert.Equal(t, jwt.ErrInvalidIssuer, err)
+	})
+
+	t.Run("invalid formats", func(t *testing.T) {
+		testCases := []struct {
+			token string
+			err   error
+		}{
+			{"", fmt.Errorf("square/go-jose: compact JWS format must have three parts")},
+			{"a", fmt.Errorf("square/go-jose: compact JWS format must have three parts")},
+			{"a.b", fmt.Errorf("square/go-jose: compact JWS format must have three parts")},
+			{"a.b.c", base64.CorruptInputError(0)},
+		}
+
+		for _, tc := range testCases {
+			_, err := verifier.GetVerifiedClaims(tc.token)
+			assert.Equal(t, tc.err, err)
+		}
+	})
+
+	t.Run("signed by unknown keypair", func(t *testing.T) {
+		unknownKey, err := rsa.GenerateKey(rand.Reader, 512)
+		require.NoError(t, err)
+		unknownJWK := jose.JSONWebKey{Key: unknownKey, KeyID: "unknownKey"}
+		unknownSigner, err := jose.NewSigner(
+			jose.SigningKey{Algorithm: jose.RS256, Key: unknownJWK},
+			(&jose.SignerOptions{}).WithType("JWT"),
+		)
+		require.NoError(t, err)
+
+		token, err := jwt.Signed(unknownSigner).Claims(defaultClaims).CompactSerialize()
+		require.NoError(t, err)
+
+		_, err = verifier.GetVerifiedClaims(token)
+		assert.Equal(t, ErrNoKey, err)
+	})
+
+	t.Run("alg=none attack", func(t *testing.T) {
+		token, err := jwt.Signed(defaultSigner).Claims(defaultClaims).CompactSerialize()
+		require.NoError(t, err)
+
+		token = swapHeader(token, map[string]string{"alg": "none", "type": "JWT"})
+
+		_, err = verifier.GetVerifiedClaims(token)
+		assert.Equal(t, ErrNoKey, err)
+	})
+
+	t.Run("alg=hmac attack", func(t *testing.T) {
+		// this hmac signer uses the public key to sign, in hopes that the verifier will naively use
+		// it to verify.
+		jwkJSON, err := jwks.key_map[defaultJWK.KeyID].MarshalJSON()
+		require.NoError(t, err)
+		hmacSigner, err := jose.NewSigner(
+			jose.SigningKey{Algorithm: jose.HS256, Key: jwkJSON},
+			(&jose.SignerOptions{}).WithType("JWT"),
+		)
+		require.NoError(t, err)
+
+		token, err := jwt.Signed(hmacSigner).Claims(defaultClaims).CompactSerialize()
+		require.NoError(t, err)
+
+		token = swapHeader(token, map[string]string{"alg": "HS256", "type": "JWT", "kid": defaultJWK.KeyID})
+
+		_, err = verifier.GetVerifiedClaims(token)
+		assert.Equal(t, jose.ErrCryptoFailure, err)
+	})
+
+	t.Run("wrong issuer", func(t *testing.T) {
+		testClaims := defaultClaims
+		testClaims.Issuer = "https://authn.elsewhere.com"
+		token, err := jwt.Signed(defaultSigner).Claims(testClaims).CompactSerialize()
+		require.NoError(t, err)
+
+		_, err = verifier.GetVerifiedClaims(token)
+		assert.Equal(t, jwt.ErrInvalidIssuer, err)
+	})
+
+	t.Run("wrong audience", func(t *testing.T) {
+		testClaims := defaultClaims
+		testClaims.Audience = jwt.Audience{"app.elsewhere.com"}
+		token, err := jwt.Signed(defaultSigner).Claims(testClaims).CompactSerialize()
+		require.NoError(t, err)
+
+		_, err = verifier.GetVerifiedClaims(token)
+		assert.Equal(t, jwt.ErrInvalidAudience, err)
+	})
+
+	t.Run("tampered subject", func(t *testing.T) {
+		token, err := jwt.Signed(defaultSigner).Claims(defaultClaims).CompactSerialize()
+		require.NoError(t, err)
+
+		_, err = verifier.GetVerifiedClaims(mergeClaims(token, map[string]string{"sub": "null"}))
+		assert.Equal(t, jose.ErrCryptoFailure, err)
+	})
+
+	t.Run("expired", func(t *testing.T) {
+		testClaims := defaultClaims
+		testClaims.Expiry = jwt.NewNumericDate(time.Now().Add(-time.Hour))
+		token, err := jwt.Signed(defaultSigner).Claims(testClaims).CompactSerialize()
+		require.NoError(t, err)
+
+		_, err = verifier.GetVerifiedClaims(token)
+		assert.Equal(t, jwt.ErrExpired, err)
+	})
+}
+
+func swapHeader(token string, newHeader map[string]string) string {
+	bytes, err := json.Marshal(newHeader)
+	if err != nil {
+		panic(err)
+	}
+
+	parts := strings.Split(token, ".")
+	parts[0] = base64.RawStdEncoding.EncodeToString(bytes)
+	return strings.Join(parts, ".")
+}
+
+func mergeClaims(token string, newClaims map[string]string) string {
+	parts := strings.Split(token, ".")
+
+	// decode
+	var claims map[string]interface{}
+	raw, err := base64.RawStdEncoding.DecodeString(parts[1])
+	if err != nil {
+		panic(err)
+	}
+	err = json.Unmarshal(raw, &claims)
+	if err != nil {
+		panic(err)
+	}
+
+	// the merge
+	for k, v := range newClaims {
+		claims[k] = v
+	}
+
+	// re-encode
+	bytes, err := json.Marshal(claims)
+	if err != nil {
+		panic(err)
+	}
+	parts[1] = base64.RawStdEncoding.EncodeToString(bytes)
+	return strings.Join(parts, ".")
+}


### PR DESCRIPTION
Tests for `idTokenVerifier` are referenced from https://github.com/keratin/authn-rb/blob/master/test/keratin_authn_test.rb.

There's also some test coverage and a bugfix for `internalClient` when the AuthN server is mounted with a subdir. Tests for `Key()` are still TBD.