### PR TITLE
Travis builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+go:
+  - 1.x
+
+before_install:
+  - sudo add-apt-repository ppa:masterminds/glide -y
+  - sudo apt-get update -q
+  - sudo apt-get install glide -y
+install:
+  - make vendor
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+PKGS := $(shell glide nv)
+ORG := keratin
+PROJECT := authn-go
+NAME := $(ORG)/$(PROJECT)
+VERSION := 0.1.0
+
+.PHONY: clean
+clean:
+	rm -rf vendor
+
+# Fetch dependencies
+vendor:
+	glide install
+
+# Run tests
+.PHONY: test
+test: vendor
+	go test $(PKGS)
+
+# Cut a release of the current version.
+.PHONY: release
+release: test
+	git tag v$(VERSION)
+	git push --tags
+	open https://github.com/$(NAME)/releases/tag/v$(VERSION)

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,30 @@
+hash: 7e28386a3cb7a5866d1129c1717b7238986e7b21b764b9077bcfddb3a11e9952
+updated: 2017-12-06T22:00:44.610852-08:00
+imports:
+- name: github.com/patrickmn/go-cache
+  version: a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0
+- name: golang.org/x/crypto
+  version: adbae1b6b6fb4b02448a0fc0dbbc9ba2b95b294d
+  subpackages:
+  - ed25519
+  - ed25519/internal/edwards25519
+- name: gopkg.in/square/go-jose.v2
+  version: f8f38de21b4dcd69d0413faf231983f5fd6634b1
+  subpackages:
+  - cipher
+  - json
+  - jwt
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  subpackages:
+  - assert
+  - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,14 @@
+package: github.com/keratin/authn-go
+import:
+- package: github.com/patrickmn/go-cache
+  version: ^2.1.0
+- package: gopkg.in/square/go-jose.v2
+  version: ^2.1.3
+  subpackages:
+  - jwt
+testImport:
+- package: github.com/stretchr/testify
+  version: ^1.1.4
+  subpackages:
+  - assert
+  - require


### PR DESCRIPTION
Enables Travis tests, using glide to manage dependencies. I've also included a stripped-down Makefile from keratin/authn-server.