### PR TITLE
Add ClaimsFrom and ClaimsFromWithAudience

### DIFF
--- a/authn/authn.go
+++ b/authn/authn.go
@@ -55,26 +55,51 @@ func (ac *Client) SubjectFrom(idToken string) (string, error) {
 }
 
 // SubjectFromWithAudience works like SubjectFrom but allows specifying a different
-// JWT audience
+// JWT audience.
 func (ac *Client) SubjectFromWithAudience(idToken string, audience jwt.Audience) (string, error) {
 	verifier, err := newIDTokenVerifierWithAudiences(ac.config.Issuer, audience, ac.kchain)
 	if err != nil {
 		return "", err
 	}
-
 	return ac.subjectFromVerifier(idToken, verifier)
 }
 
+// ClaimsFrom will return all verified claims inside the given idToken
+// if and only if the token is a valid JWT that passes all
+// verification requirements. If the JWT does not verify, the returned
+// error will explain why. This is for debugging purposes.
+func (ac *Client) ClaimsFrom(idToken string) (*jwt.Claims, error) {
+	return ac.claimsFromVerifier(idToken, ac.verifier)
+}
+
+// ClaimsFromWithAudience works like ClaimsFrom but allows
+// specifying a different JWT audience.
+func (ac *Client) ClaimsFromWithAudience(idToken string, audience jwt.Audience) (*jwt.Claims, error) {
+	verifier, err := newIDTokenVerifierWithAudiences(ac.config.Issuer, audience, ac.kchain)
+	if err != nil {
+		return nil, err
+	}
+	return ac.claimsFromVerifier(idToken, verifier)
+}
+
 func (ac *Client) subjectFromVerifier(idToken string, verifier JWTClaimsExtractor) (string, error) {
-	claims, err := verifier.GetVerifiedClaims(idToken)
+	claims, err := ac.claimsFromVerifier(idToken, verifier)
 	if err != nil {
 		return "", err
 	}
 	return claims.Subject, nil
 }
 
+func (ac *Client) claimsFromVerifier(idToken string, verifier JWTClaimsExtractor) (*jwt.Claims, error) {
+	claims, err := verifier.GetVerifiedClaims(idToken)
+	if err != nil {
+		return nil, err
+	}
+	return claims, nil
+}
+
 // GetAccount gets the account with the associated id
-func (ac *Client) GetAccount(id string) (*Account, error) { //Should this be a string or an int?
+func (ac *Client) GetAccount(id string) (*Account, error) { // Should this be a string or an int?
 	return ac.iclient.GetAccount(id)
 }
 


### PR DESCRIPTION
This patch adds two methods to the authn-go client: ClaimsFrom and its derivative, ClaimsFromWithAudience. These methods return the verified claims for the given ID token, if and only if the token is a valid JWT passing all verification requirements.

Closes https://github.com/keratin/authn-go/issues/17.